### PR TITLE
Update deposit function

### DIFF
--- a/BondDepository.sol
+++ b/BondDepository.sol
@@ -698,7 +698,7 @@ contract TimeBondDepository is Ownable {
         if ( fee != 0 ) { // fee is transferred to dao 
             Time.safeTransfer( DAO, fee ); 
         }
-        require(balanceBefore.add(profit) == Time.balanceOf(address(this)), "Not enough Time to cover profit");
+        require(balanceBefore.add(payout) == Time.balanceOf(address(this)), "Not enough Time to cover profit");
         // total debt is increased
         totalDebt = totalDebt.add( value ); 
                 


### PR DESCRIPTION
Removed "require" that always fails, as the bond's expected balance of TIME should be: balanceBefore + payout

Depositing in the treasury an amount and profit would make the treasury mint amount - profit TIME to the bond. Then the DAO fee amount is used to send to the DAO. So the Bond's balance left is its balance before the deposit plus the payout to the bonder.